### PR TITLE
feat: animated equalizer + dynamic SIDE label

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
             <rect x="18" y="5" width="184" height="54" rx="3" fill="#e8e3d8"/>
             <line x1="26" y1="20" x2="140" y2="20" stroke="#c5bfb0" stroke-width="1.5" stroke-linecap="round"/>
             <line x1="26" y1="28" x2="120" y2="28" stroke="#c5bfb0" stroke-width="1" stroke-linecap="round" opacity="0.6"/>
-            <text x="192" y="53" text-anchor="end" font-size="5.5" fill="#8a8478"
+            <text id="sideLabel" x="192" y="53" text-anchor="end" font-size="5.5" fill="#8a8478"
                   font-family="'DM Mono', monospace" letter-spacing="1.5">SIDE A</text>
 
             <g id="replaySvgBtn" cursor="pointer">
@@ -124,7 +124,10 @@
         </div>
 
         <div class="track-meta">
-          <span class="track-name" id="trackName">Beat Yourself Up — Charlie Puth</span>
+          <div class="track-name-wrap">
+            <span class="eq" aria-hidden="true"><i></i><i></i><i></i><i></i></span>
+            <span class="track-name" id="trackName">Beat Yourself Up — Charlie Puth</span>
+          </div>
           <span class="track-time" id="trackTime"></span>
         </div>
       </div>

--- a/player.js
+++ b/player.js
@@ -28,6 +28,8 @@
   const trackName    = document.getElementById('trackName');
   const trackTime    = document.getElementById('trackTime');
   const playHint     = document.getElementById('playHint');
+  const sideLabel    = document.getElementById('sideLabel');
+  const player       = document.querySelector('.player');
 
   let playing = false;
 
@@ -39,6 +41,7 @@
   function setState(state) {
     playing = state;
     wrap.classList.toggle('playing', state);
+    if (player) player.classList.toggle('playing', state);
     wrap.setAttribute('aria-label', state ? 'Pause music' : 'Play music');
     if (state && playHint) playHint.classList.add('hidden');
   }
@@ -49,6 +52,7 @@
     trackName.textContent = song.title;
     trackTime.textContent = '';
     progressBar.style.width = '0%';
+    if (sideLabel) sideLabel.textContent = 'SIDE ' + String.fromCharCode(65 + pos);
     if (autoplay) {
       audio.play()
         .then(() => setState(true))

--- a/style.css
+++ b/style.css
@@ -150,11 +150,39 @@ body { font-family: 'DM Mono', monospace; color: var(--cream); background: var(-
   display: flex; justify-content: space-between; align-items: center;
   margin-top: 7px;
 }
+.track-name-wrap {
+  display: flex; align-items: center; gap: 4px;
+  overflow: hidden; max-width: 148px;
+}
 .track-name, .track-time {
   font-size: 0.52rem; letter-spacing: 0.1em;
   color: var(--cream-22); font-weight: 300;
+  transition: color 0.4s ease;
 }
-.track-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 140px; }
+.track-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.player.playing .track-name { color: var(--cream-45); }
+
+.eq {
+  display: inline-flex; align-items: flex-end; gap: 1.5px;
+  height: 7px; flex-shrink: 0;
+  opacity: 0; transition: opacity 0.5s ease;
+}
+.eq i {
+  display: block; width: 1.5px; height: 100%;
+  background: var(--gold); border-radius: 1px;
+  transform-origin: bottom; transform: scaleY(0.15);
+  animation-play-state: paused;
+}
+@keyframes eq-bar {
+  0%   { transform: scaleY(0.15); }
+  100% { transform: scaleY(1);    }
+}
+.eq i:nth-child(1) { animation: eq-bar 0.65s ease-in-out 0s    infinite alternate; }
+.eq i:nth-child(2) { animation: eq-bar 0.45s ease-in-out 0.1s  infinite alternate; }
+.eq i:nth-child(3) { animation: eq-bar 0.75s ease-in-out 0.22s infinite alternate; }
+.eq i:nth-child(4) { animation: eq-bar 0.55s ease-in-out 0.08s infinite alternate; }
+.player.playing .eq         { opacity: 1; }
+.player.playing .eq i       { animation-play-state: running; }
 
 .links {
   list-style: none; display: flex; flex-wrap: wrap; gap: 0.45rem 2rem;


### PR DESCRIPTION
## Summary
- 4 gold equalizer bars animate beside the track name while music plays — a classic "now playing" signifier that fits the cassette aesthetic perfectly
- Cassette cream label updates SIDE A → B → C → D as you cycle through the shuffled queue
- Track name text brightens slightly when playing

## Changes
- `index.html` — `id="sideLabel"` on the SIDE text; wraps track name in `.track-name-wrap` with `.eq` bars
- `style.css` — `.eq` / `eq-bar` keyframes; `.player.playing` toggles bars on; track name color transition
- `player.js` — adds `player` + `sideLabel` refs; toggles `.playing` on player container; updates SIDE label per queue position in `loadSong`

## Test plan
- [ ] Hit play — 4 gold bars animate next to the track name
- [ ] Pause — bars freeze and fade out
- [ ] Click next — SIDE label updates (A → B → C → D → A)
- [ ] Track name is dimmer when paused, slightly brighter when playing

Generated with Claude Code