### PR TITLE
polish: readable aside + link group separator

### DIFF
--- a/style.css
+++ b/style.css
@@ -221,7 +221,7 @@ body { font-family: 'DM Mono', monospace; color: var(--cream); background: var(-
 
 .aside {
   font-size: clamp(0.6rem, 1vw, 0.68rem); font-weight: 300; font-style: italic;
-  color: var(--cream-22); letter-spacing: 0.04em;
+  color: rgba(240, 235, 224, 0.35); letter-spacing: 0.04em;
   opacity: 0; animation: rise 1s cubic-bezier(0.16, 1, 0.3, 1) 0.78s forwards;
 }
 .aside a { color: inherit; text-decoration: underline; text-underline-offset: 3px; transition: color 0.2s ease; }
@@ -244,7 +244,10 @@ body { font-family: 'DM Mono', monospace; color: var(--cream); background: var(-
   }
   .links { flex-direction: column; gap: 0.2rem 0; margin-bottom: 2rem; }
   .row-break { display: none !important; }
-  .social-github { margin-top: 0.75rem; }
+  .social-github {
+    margin-top: 1rem; padding-top: 0.8rem;
+    border-top: 1px solid rgba(240, 235, 224, 0.1);
+  }
 }
 
 @media (max-width: 539px) {


### PR DESCRIPTION
## Summary
- Aside text opacity bumped from 22% → 35% — "Periodic life update" was readable only on close inspection; it's a personal touch that deserves to actually be seen
- Thin `border-top` (10% cream) separates writing links from social links on desktop, making the two groups feel intentional rather than one long list

## Changes
- `style.css` only — two targeted tweaks, no structural changes

## Test plan
- [ ] Desktop: thin line visible between Love Poetry and GitHub
- [ ] Mobile: no line (border-top only applies in the 900px+ media query)
- [ ] Aside text is legible without being loud

Generated with Claude Code