### PR TITLE
fix: GitHub/Instagram/LinkedIn always on same row on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,38 +137,42 @@
         <li><a href="https://www.notion.so/nguyenv119/Writing-322250e457388052b711fb53e584fd9c?source=copy_link"><span>📝</span>Writing</a></li>
         <li><a href="https://www.notion.so/nguyenv119/Love-Poetry-2c7250e4573880ceb982c0836594fd66?source=copy_link"><span>💜</span>Love Poetry</a></li>
         <li class="row-break" aria-hidden="true" style="flex-basis:100%;height:0;margin:0;padding:0"></li>
-        <li class="social-github"><a href="https://github.com/nguyenv119">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-          </svg>
-          GitHub
-        </a></li>
-        <li class="social-instagram"><a href="https://www.instagram.com/vlong_codes/">
-          <svg viewBox="0 0 24 24" fill="none" stroke-width="1.75"
-               stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <defs>
-              <linearGradient id="ig-g" x1="0" y1="24" x2="24" y2="0" gradientUnits="userSpaceOnUse">
-                <stop offset="0%"   stop-color="#f09433"/>
-                <stop offset="25%"  stop-color="#e6683c"/>
-                <stop offset="50%"  stop-color="#dc2743"/>
-                <stop offset="75%"  stop-color="#cc2366"/>
-                <stop offset="100%" stop-color="#bc1888"/>
-              </linearGradient>
-            </defs>
-            <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="url(#ig-g)"/>
-            <circle cx="12" cy="12" r="4" stroke="url(#ig-g)"/>
-            <circle cx="17.5" cy="6.5" r="0.6" fill="url(#ig-g)" stroke="none"/>
-          </svg>
-          Instagram
-        </a></li>
-        <li class="social-linkedin"><a href="https://www.linkedin.com/in/nguyenv119/">
-          <svg viewBox="0 0 24 24" fill="#0a66c2" aria-hidden="true">
-            <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/>
-            <rect x="2" y="9" width="4" height="12"/>
-            <circle cx="4" cy="4" r="2"/>
-          </svg>
-          LinkedIn
-        </a></li>
+        <li class="social-row">
+          <ul class="social-links">
+            <li class="social-github"><a href="https://github.com/nguyenv119">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+              </svg>
+              GitHub
+            </a></li>
+            <li class="social-instagram"><a href="https://www.instagram.com/vlong_codes/">
+              <svg viewBox="0 0 24 24" fill="none" stroke-width="1.75"
+                   stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <defs>
+                  <linearGradient id="ig-g" x1="0" y1="24" x2="24" y2="0" gradientUnits="userSpaceOnUse">
+                    <stop offset="0%"   stop-color="#f09433"/>
+                    <stop offset="25%"  stop-color="#e6683c"/>
+                    <stop offset="50%"  stop-color="#dc2743"/>
+                    <stop offset="75%"  stop-color="#cc2366"/>
+                    <stop offset="100%" stop-color="#bc1888"/>
+                  </linearGradient>
+                </defs>
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="url(#ig-g)"/>
+                <circle cx="12" cy="12" r="4" stroke="url(#ig-g)"/>
+                <circle cx="17.5" cy="6.5" r="0.6" fill="url(#ig-g)" stroke="none"/>
+              </svg>
+              Instagram
+            </a></li>
+            <li class="social-linkedin"><a href="https://www.linkedin.com/in/nguyenv119/">
+              <svg viewBox="0 0 24 24" fill="#0a66c2" aria-hidden="true">
+                <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/>
+                <rect x="2" y="9" width="4" height="12"/>
+                <circle cx="4" cy="4" r="2"/>
+              </svg>
+              LinkedIn
+            </a></li>
+          </ul>
+        </li>
       </ul>
 
       <p class="aside">Periodic life update: thanks Mel Robbins for <a href="https://www.youtube.com/watch?v=P91b4civBxA">this</a></p>

--- a/style.css
+++ b/style.css
@@ -189,7 +189,14 @@ body { font-family: 'DM Mono', monospace; color: var(--cream); background: var(-
   margin-bottom: 2.25rem;
   opacity: 0; animation: rise 1s cubic-bezier(0.16, 1, 0.3, 1) 0.58s forwards;
 }
-.social-github { margin-top: 0.35rem; }
+.social-row {
+  flex-basis: 100%; /* always its own row in mobile flex-wrap */
+  margin-top: 0.35rem;
+}
+.social-links {
+  list-style: none; display: flex; flex-wrap: nowrap; gap: 1.5rem;
+  align-items: center;
+}
 
 .links a {
   font-size: clamp(0.7rem, 1.2vw, 0.8rem); font-weight: 400;
@@ -244,7 +251,8 @@ body { font-family: 'DM Mono', monospace; color: var(--cream); background: var(-
   }
   .links { flex-direction: column; gap: 0.2rem 0; margin-bottom: 2rem; }
   .row-break { display: none !important; }
-  .social-github { margin-top: 0.75rem; }
+  .social-row { flex-basis: auto; margin-top: 0.75rem; }
+  .social-links { flex-direction: column; gap: 0.2rem 0; }
 }
 
 @media (max-width: 539px) {


### PR DESCRIPTION
## Problem
The 3 social links (GitHub, Instagram, LinkedIn) were loose `<li>` elements in a `flex-wrap` container, allowing them to split across rows at certain viewport widths.

## Fix
Wraps all 3 inside a single `<li class="social-row"><ul class="social-links">` container:
- `.social-row { flex-basis: 100% }` — takes a full row in the mobile flex-wrap layout, always starting on its own line
- `.social-links { flex-wrap: nowrap }` — the 3 links inside never break to separate rows
- On desktop (≥900px): collapses back to a column-flex item, preserving the existing stacked layout

## Test plan
- [ ] Mobile narrow (~320px): GitHub | Instagram | LinkedIn all on one row
- [ ] Mobile wide (~540px): same
- [ ] Desktop: GitHub, Instagram, LinkedIn still stack vertically in the right column

Generated with Claude Code