### PR TITLE
fix(mobile): GitHub on same row as Instagram and LinkedIn

### DIFF
--- a/style.css
+++ b/style.css
@@ -247,6 +247,13 @@ body { font-family: 'DM Mono', monospace; color: var(--cream); background: var(-
   .social-github { margin-top: 0.75rem; }
 }
 
-@media (max-width: 539px) {
-  .links { gap: 0.55rem 1.5rem; }
+@media (max-width: 899px) {
+  .links {
+    display: grid;
+    grid-template-columns: repeat(3, auto);
+    column-gap: 1.5rem;
+    row-gap: 0.55rem;
+    justify-content: start;
+  }
+  .row-break { display: none; }
 }


### PR DESCRIPTION
## Summary
- Switches mobile links layout from `flex-wrap` to a 3-column CSS grid
- GitHub, Instagram, LinkedIn now always appear on one row on mobile
- Hides the flex `row-break` element (unused in grid context)
- **No HTML changes** — pure CSS fix, zero risk to desktop layout
- Breakpoint aligned to `<900px` (matches existing desktop threshold)

## Test plan
- [ ] Mobile (≤899px): all three social links appear on the same row
- [ ] Desktop (≥900px): vertical column layout unchanged
- [ ] Tablet (600–899px): grid layout looks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)