### PR TITLE
feat: persistent music playback across page navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,15 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;1,300;1,400&family=DM+Mono:ital,wght@0,300;0,400;1,300&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="css/page.css">
 </head>
 
 <body>
+  <audio id="audio" preload="auto"></audio>
   <div class="bg" aria-hidden="true"></div>
   <div class="grain" aria-hidden="true"></div>
 
+  <div id="content">
   <div class="stage">
 
     <div class="left">
@@ -22,8 +25,6 @@
       <p class="tagline">like the adjective</p>
 
       <div class="player">
-        <audio id="audio" preload="auto"></audio>
-
         <div class="cassette-wrap" id="cassetteWrap"
              role="button" tabindex="0"
              aria-label="Play music" title="play / pause">
@@ -133,9 +134,9 @@
 
     <div class="right">
       <ul class="links">
-        <li><a href="pages/engineering.html" target="_blank" rel="noopener noreferrer"><span>✍️</span>Eng Blog</a></li>
-        <li><a href="pages/writing.html" target="_blank" rel="noopener noreferrer"><span>📝</span>Writing</a></li>
-        <li><a href="pages/love-poetry.html" target="_blank" rel="noopener noreferrer"><span>💜</span>Love Poetry</a></li>
+        <li><a href="pages/engineering.html"><span>✍️</span>Eng Blog</a></li>
+        <li><a href="pages/writing.html"><span>📝</span>Writing</a></li>
+        <li><a href="pages/love-poetry.html"><span>💜</span>Love Poetry</a></li>
         <li class="row-break" aria-hidden="true" style="flex-basis:100%;height:0;margin:0;padding:0"></li>
         <li class="social-github"><a href="https://github.com/nguyenv119" target="_blank" rel="noopener noreferrer">
           <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -175,7 +176,9 @@
     </div>
 
   </div>
+  </div>
 
+  <script src="js/router.js"></script>
   <script src="js/player.js"></script>
 </body>
 </html>

--- a/js/player.js
+++ b/js/player.js
@@ -1,5 +1,5 @@
 (function () {
-  const SONGS = [
+  var SONGS = [
     { src: 'mewsics/byu_charlieputh.mp3',  title: 'Beat Yourself Up — Charlie Puth'  },
     { src: 'mewsics/cry_charlieputh.mp3',   title: 'Cry — Charlie Puth'              },
     { src: 'mewsics/endworld_searows.mp3',  title: 'End of the World — Searows'      },
@@ -7,31 +7,25 @@
   ];
 
   function shuffle(arr) {
-    const a = arr.slice();
-    for (let i = a.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [a[i], a[j]] = [a[j], a[i]];
+    var a = arr.slice();
+    for (var i = a.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var tmp = a[i]; a[i] = a[j]; a[j] = tmp;
     }
     return a;
   }
 
-  const queue    = shuffle(SONGS.map((_, i) => i));
-  let   queuePos = 0;
+  var queue    = shuffle(SONGS.map(function (_, i) { return i; }));
+  var queuePos = 0;
 
-  const audio        = document.getElementById('audio');
-  const wrap         = document.getElementById('cassetteWrap');
-  const replayBtn    = document.getElementById('replaySvgBtn');
-  const prevBtn      = document.getElementById('prevBtn');
-  const nextBtn      = document.getElementById('nextBtn');
-  const progressWrap = document.getElementById('progressWrap');
-  const progressBar  = document.getElementById('progressBar');
-  const trackName    = document.getElementById('trackName');
-  const trackTime    = document.getElementById('trackTime');
-  const playHint     = document.getElementById('playHint');
-  const sideLabel    = document.getElementById('sideLabel');
-  const player       = document.querySelector('.player');
+  // Audio element persists (lives outside #content)
+  var audio = document.getElementById('audio');
 
-  let playing = false;
+  // Mutable DOM references — updated by bindUI()
+  var wrap, replayBtn, prevBtn, nextBtn, progressWrap, progressBar;
+  var trackName, trackTime, playHint, sideLabel, player;
+
+  var playing = false;
 
   function fmt(s) {
     if (!s || !isFinite(s)) return '';
@@ -40,30 +34,32 @@
 
   function setState(state) {
     playing = state;
-    wrap.classList.toggle('playing', state);
+    if (wrap) {
+      wrap.classList.toggle('playing', state);
+      wrap.setAttribute('aria-label', state ? 'Pause music' : 'Play music');
+    }
     if (player) player.classList.toggle('playing', state);
-    wrap.setAttribute('aria-label', state ? 'Pause music' : 'Play music');
     if (state && playHint) playHint.classList.add('hidden');
   }
 
   function loadSong(pos, autoplay) {
-    const song = SONGS[queue[pos]];
+    var song = SONGS[queue[pos]];
     audio.src = song.src;
-    trackName.textContent = song.title;
-    trackTime.textContent = '';
-    progressBar.style.width = '0%';
+    if (trackName) trackName.textContent = song.title;
+    if (trackTime) trackTime.textContent = '';
+    if (progressBar) progressBar.style.width = '0%';
     if (sideLabel) sideLabel.textContent = 'SIDE ' + String.fromCharCode(65 + pos);
     if (autoplay) {
       audio.play()
-        .then(() => setState(true))
-        .catch(() => setState(false));
+        .then(function () { setState(true); })
+        .catch(function () { setState(false); });
     }
   }
 
   function tryPlay() {
     audio.play()
-      .then(() => setState(true))
-      .catch(() => setState(false));
+      .then(function () { setState(true); })
+      .catch(function () { setState(false); });
   }
 
   function pause() { audio.pause(); setState(false); }
@@ -82,40 +78,80 @@
     }
   }
 
+  // Bind (or re-bind) UI elements and their click handlers.
+  // Called on initial load and whenever the homepage content is restored via SPA.
+  function bindUI() {
+    wrap         = document.getElementById('cassetteWrap');
+    replayBtn    = document.getElementById('replaySvgBtn');
+    prevBtn      = document.getElementById('prevBtn');
+    nextBtn      = document.getElementById('nextBtn');
+    progressWrap = document.getElementById('progressWrap');
+    progressBar  = document.getElementById('progressBar');
+    trackName    = document.getElementById('trackName');
+    trackTime    = document.getElementById('trackTime');
+    playHint     = document.getElementById('playHint');
+    sideLabel    = document.getElementById('sideLabel');
+    player       = document.querySelector('.player');
+
+    if (!wrap) return; // Not on homepage — nothing to bind
+
+    // Sync visual state with current audio state
+    setState(playing);
+
+    // Sync track info display
+    var song = SONGS[queue[queuePos]];
+    if (trackName) trackName.textContent = song.title;
+    if (sideLabel) sideLabel.textContent = 'SIDE ' + String.fromCharCode(65 + queuePos);
+    if (progressBar && audio.duration && isFinite(audio.duration)) {
+      progressBar.style.width = (audio.currentTime / audio.duration * 100) + '%';
+    }
+    if (trackTime && audio.duration && isFinite(audio.duration)) {
+      trackTime.textContent = fmt(audio.currentTime) + ' / ' + fmt(audio.duration);
+    }
+
+    // Click handlers on freshly inserted DOM elements
+    wrap.addEventListener('click', function () { playing ? pause() : tryPlay(); });
+    wrap.addEventListener('keydown', function (e) {
+      if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); playing ? pause() : tryPlay(); }
+    });
+
+    replayBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      audio.currentTime = 0;
+      if (!playing) tryPlay();
+    });
+
+    prevBtn.addEventListener('click', function (e) { e.stopPropagation(); goPrev(); });
+    nextBtn.addEventListener('click', function (e) { e.stopPropagation(); goNext(); });
+
+    progressWrap.addEventListener('click', function (e) {
+      if (!audio.duration || isNaN(audio.duration)) return;
+      var r = this.getBoundingClientRect();
+      audio.currentTime = ((e.clientX - r.left) / r.width) * audio.duration;
+    });
+  }
+
+  // Audio event listeners — attached ONCE to the persistent audio element.
+  // They use the mutable DOM refs which get updated by bindUI().
+  audio.addEventListener('play',  function () { setState(true); });
+  audio.addEventListener('pause', function () { setState(false); });
+  audio.addEventListener('ended', function () { setState(false); goNext(); });
+
+  audio.addEventListener('timeupdate', function () {
+    if (!audio.duration || isNaN(audio.duration)) return;
+    if (progressBar) progressBar.style.width = (audio.currentTime / audio.duration * 100) + '%';
+    if (trackTime) trackTime.textContent = fmt(audio.currentTime) + ' / ' + fmt(audio.duration);
+  });
+
+  audio.addEventListener('loadedmetadata', function () {
+    if (trackTime) trackTime.textContent = '0:00 / ' + fmt(audio.duration);
+  });
+
+  // Initial load
   loadSong(0, false);
-  audio.addEventListener('canplay', () => { if (!playing) tryPlay(); }, { once: true });
+  audio.addEventListener('canplay', function () { if (!playing) tryPlay(); }, { once: true });
+  bindUI();
 
-  wrap.addEventListener('click', () => playing ? pause() : tryPlay());
-  wrap.addEventListener('keydown', e => {
-    if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); playing ? pause() : tryPlay(); }
-  });
-  
-  replayBtn.addEventListener('click', e => {
-    e.stopPropagation();
-    audio.currentTime = 0;
-    if (!playing) tryPlay();
-  });
-
-  prevBtn.addEventListener('click', e => { e.stopPropagation(); goPrev(); });
-  nextBtn.addEventListener('click', e => { e.stopPropagation(); goNext(); });
-
-  audio.addEventListener('play',  () => setState(true));
-  audio.addEventListener('pause', () => setState(false));
-  audio.addEventListener('ended', () => { setState(false); goNext(); });
-
-  audio.addEventListener('timeupdate', () => {
-    if (!audio.duration || isNaN(audio.duration)) return;
-    progressBar.style.width = (audio.currentTime / audio.duration * 100) + '%';
-    trackTime.textContent   = fmt(audio.currentTime) + ' / ' + fmt(audio.duration);
-  });
-
-  progressWrap.addEventListener('click', function (e) {
-    if (!audio.duration || isNaN(audio.duration)) return;
-    const r = this.getBoundingClientRect();
-    audio.currentTime = ((e.clientX - r.left) / r.width) * audio.duration;
-  });
-
-  audio.addEventListener('loadedmetadata', () => {
-    trackTime.textContent = '0:00 / ' + fmt(audio.duration);
-  });
+  // Expose for the SPA router
+  window.__playerBindUI = bindUI;
 })();

--- a/js/router.js
+++ b/js/router.js
@@ -2,34 +2,32 @@
   var CONTENT = document.getElementById('content');
   var BG = document.querySelector('.bg');
 
-  // Paths that are internal pages (relative from root)
-  function isInternalPath(path) {
-    return /^(\/?(pages\/[^/]+\.html|index\.html)?)$/.test(path) ||
-           path === '/' || path === '';
+  // Derive base path from where index.html lives
+  // e.g. "/nguyenv119-spa-persistent-music/" or "/"
+  var BASE = location.pathname.replace(/\/index\.html$/, '').replace(/\/$/, '') + '/';
+
+  function isHomePath(path) {
+    return path === BASE || path === BASE + 'index.html';
   }
 
-  // Normalize href to a path relative to site root
+  function isInternalPath(path) {
+    if (isHomePath(path)) return true;
+    // Match BASE + pages/something.html
+    return path.indexOf(BASE + 'pages/') === 0 && path.endsWith('.html');
+  }
+
+  // Resolve href relative to the current page, return absolute pathname
   function normalizePath(href) {
     try {
-      var url = new URL(href, location.origin);
+      var url = new URL(href, location.href);
       if (url.origin !== location.origin) return null;
-      var p = url.pathname;
-      // ../index.html -> /index.html
-      // pages/X.html -> /pages/X.html
-      // Ensure leading slash
-      if (!p.startsWith('/')) p = '/' + p;
-      return p;
+      return url.pathname;
     } catch (_) {
       return null;
     }
   }
 
-  function isHomePath(path) {
-    return path === '/' || path === '/index.html';
-  }
-
   function navigate(path, pushState) {
-    // Fetch the target page
     fetch(path)
       .then(function (res) {
         if (!res.ok) throw new Error(res.status);
@@ -48,20 +46,23 @@
           newContent = page ? page.outerHTML : '';
         }
 
-        // Swap content
         CONTENT.innerHTML = newContent;
 
-        // Update background
-        var fetchedBg = doc.querySelector('.bg');
-        if (fetchedBg) {
-          BG.setAttribute('style', fetchedBg.getAttribute('style') || '');
-        } else {
-          BG.removeAttribute('style');
-        }
-
-        // For homepage, the bg image is set via CSS (no inline style)
+        // Update background — resolve relative image URLs against the fetched page's path
         if (isHomePath(path)) {
           BG.removeAttribute('style');
+        } else {
+          var fetchedBg = doc.querySelector('.bg');
+          var rawStyle = fetchedBg ? fetchedBg.getAttribute('style') : '';
+          if (rawStyle) {
+            // Resolve ../images/X relative to the fetched page, not the current document
+            var fixed = rawStyle.replace(/url\(['"]?(.*?)['"]?\)/g, function (_, url) {
+              return 'url(' + new URL(url, location.origin + path).pathname + ')';
+            });
+            BG.setAttribute('style', fixed);
+          } else {
+            BG.removeAttribute('style');
+          }
         }
 
         // Toggle light-bg class
@@ -78,12 +79,10 @@
           document.title = fetchedTitle.textContent;
         }
 
-        // Push history state
         if (pushState) {
           history.pushState({ path: path }, '', path);
         }
 
-        // Scroll to top
         window.scrollTo(0, 0);
 
         // Re-bind player UI if returning to homepage
@@ -92,7 +91,6 @@
         }
       })
       .catch(function (err) {
-        // Fallback: do a normal navigation
         console.error('SPA navigation failed:', err);
         location.href = path;
       });
@@ -100,21 +98,17 @@
 
   // Event delegation: intercept clicks on internal links
   document.addEventListener('click', function (e) {
-    // Walk up from target to find anchor
     var link = e.target.closest('a');
     if (!link) return;
 
-    // Skip if modifier keys held (user wants new tab)
     if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
-
-    // Skip links with target="_blank"
     if (link.target === '_blank') return;
 
     var href = link.getAttribute('href');
     if (!href) return;
 
     var path = normalizePath(href);
-    if (!path) return; // external or invalid
+    if (!path) return;
     if (!isInternalPath(path)) return;
 
     e.preventDefault();

--- a/js/router.js
+++ b/js/router.js
@@ -1,0 +1,132 @@
+(function () {
+  var CONTENT = document.getElementById('content');
+  var BG = document.querySelector('.bg');
+
+  // Paths that are internal pages (relative from root)
+  function isInternalPath(path) {
+    return /^(\/?(pages\/[^/]+\.html|index\.html)?)$/.test(path) ||
+           path === '/' || path === '';
+  }
+
+  // Normalize href to a path relative to site root
+  function normalizePath(href) {
+    try {
+      var url = new URL(href, location.origin);
+      if (url.origin !== location.origin) return null;
+      var p = url.pathname;
+      // ../index.html -> /index.html
+      // pages/X.html -> /pages/X.html
+      // Ensure leading slash
+      if (!p.startsWith('/')) p = '/' + p;
+      return p;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function isHomePath(path) {
+    return path === '/' || path === '/index.html';
+  }
+
+  function navigate(path, pushState) {
+    // Fetch the target page
+    fetch(path)
+      .then(function (res) {
+        if (!res.ok) throw new Error(res.status);
+        return res.text();
+      })
+      .then(function (html) {
+        var doc = new DOMParser().parseFromString(html, 'text/html');
+
+        // Extract content to inject
+        var newContent;
+        if (isHomePath(path)) {
+          var stage = doc.querySelector('.stage');
+          newContent = stage ? stage.outerHTML : '';
+        } else {
+          var page = doc.querySelector('main.page');
+          newContent = page ? page.outerHTML : '';
+        }
+
+        // Swap content
+        CONTENT.innerHTML = newContent;
+
+        // Update background
+        var fetchedBg = doc.querySelector('.bg');
+        if (fetchedBg) {
+          BG.setAttribute('style', fetchedBg.getAttribute('style') || '');
+        } else {
+          BG.removeAttribute('style');
+        }
+
+        // For homepage, the bg image is set via CSS (no inline style)
+        if (isHomePath(path)) {
+          BG.removeAttribute('style');
+        }
+
+        // Toggle light-bg class
+        var fetchedBody = doc.querySelector('body');
+        if (fetchedBody && fetchedBody.classList.contains('light-bg')) {
+          document.body.classList.add('light-bg');
+        } else {
+          document.body.classList.remove('light-bg');
+        }
+
+        // Update document title
+        var fetchedTitle = doc.querySelector('title');
+        if (fetchedTitle) {
+          document.title = fetchedTitle.textContent;
+        }
+
+        // Push history state
+        if (pushState) {
+          history.pushState({ path: path }, '', path);
+        }
+
+        // Scroll to top
+        window.scrollTo(0, 0);
+
+        // Re-bind player UI if returning to homepage
+        if (isHomePath(path) && window.__playerBindUI) {
+          window.__playerBindUI();
+        }
+      })
+      .catch(function (err) {
+        // Fallback: do a normal navigation
+        console.error('SPA navigation failed:', err);
+        location.href = path;
+      });
+  }
+
+  // Event delegation: intercept clicks on internal links
+  document.addEventListener('click', function (e) {
+    // Walk up from target to find anchor
+    var link = e.target.closest('a');
+    if (!link) return;
+
+    // Skip if modifier keys held (user wants new tab)
+    if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
+
+    // Skip links with target="_blank"
+    if (link.target === '_blank') return;
+
+    var href = link.getAttribute('href');
+    if (!href) return;
+
+    var path = normalizePath(href);
+    if (!path) return; // external or invalid
+    if (!isInternalPath(path)) return;
+
+    e.preventDefault();
+    navigate(path, true);
+  });
+
+  // Handle back/forward
+  window.addEventListener('popstate', function (e) {
+    var path = (e.state && e.state.path) || location.pathname;
+    navigate(path, false);
+  });
+
+  // Set initial history state
+  history.replaceState({ path: location.pathname }, '', location.pathname);
+})();

--- a/pages/engineering.html
+++ b/pages/engineering.html
@@ -43,7 +43,7 @@
         </li>
       </ol>
 
-      <a href="../index.html" class="back-bottom" target="_blank" rel="noopener noreferrer">← back to home</a>
+      <a href="../index.html" class="back-bottom">← back to home</a>
     </div>
   </main>
 </body>

--- a/pages/love-poetry.html
+++ b/pages/love-poetry.html
@@ -35,7 +35,7 @@
       </p>
 
       <details open>
-        <summary>🎆 A Beautiful Disorder (12/31/2025)</summary>
+        <summary> 🎆 A Beautiful Disorder (12/31/2025)</summary>
         <div class="toggle-content">
           <iv class="poem">
             <div class="stanza">

--- a/pages/love-poetry.html
+++ b/pages/love-poetry.html
@@ -85,7 +85,7 @@
         </div>
       </details>
 
-      <a href="../index.html" class="back-bottom" target="_blank" rel="noopener noreferrer">← back to home</a>
+      <a href="../index.html" class="back-bottom">← back to home</a>
     </div>
   </main>
 </body>

--- a/pages/writing.html
+++ b/pages/writing.html
@@ -44,7 +44,7 @@
         </div>
       </details>
 
-      <a href="../index.html" class="back-bottom" target="_blank" rel="noopener noreferrer">← back to home</a>
+      <a href="../index.html" class="back-bottom">← back to home</a>
     </div>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- Convert the multi-page static site to a lightweight SPA so the cassette music player continues playing uninterrupted when navigating between pages
- The `<audio>` element lives outside the swappable content area and persists across navigations
- A vanilla JS client-side router intercepts internal link clicks, fetches page content via `fetch()`, and swaps it in without a full page reload

## Changes
- **index.html** — moved `<audio>` outside `.stage`, wrapped content in `<div id="content">`, added `page.css` to head, removed `target="_blank"` from internal links, added router script
- **js/router.js** (new) — event-delegated link interception, `DOMParser`-based content extraction, `pushState`/`popstate` history management, background image + `light-bg` class toggling, scroll-to-top on navigation
- **js/player.js** — refactored to use mutable DOM references with a `bindUI()` function that re-binds after homepage restoration; null guards on all DOM updates; audio event listeners attached once to persistent element
- **pages/*.html** — removed `target="_blank"` from "back to home" links so the router can intercept them

## Test plan
- [ ] Start music on homepage, click Eng Blog — music keeps playing
- [ ] Click "back to home" — cassette player reappears, synced to current playback
- [ ] Navigate to Love Poetry — background changes to spirited_away.jpg with light overlay
- [ ] Use browser back/forward — content swaps correctly, music uninterrupted
- [ ] External links (GitHub, Instagram, LinkedIn, Notion) still open in new tabs
- [ ] Cmd+click on internal links opens new tab (modifier key bypass)
- [ ] Direct URL load of a sub-page still works normally

Generated with Claude Code