### PR TITLE
Add essay: Non-Negotiables, Standards, Preferences

### DIFF
--- a/pages/writing.html
+++ b/pages/writing.html
@@ -25,7 +25,7 @@
     <div class="page-body">
 
       <details>
-        <summary> Non-Negotiables, Standards, Preferences (04/06/2026)</summary>
+        <summary> What we should actually look for in someone (04/06/2026)</summary>
         <div class="toggle-content">
           <p>You probably have some list of what you want in someone. "6ft, makes 200k+, kind, emotionally mature." But I'd like to question that today — what does that actually mean? Because to me, your list of traits, when stripped down, are actually about how you want to feel.</p>
           <p>Height isn't the goal — feeling protected, or small in a way that feels safe. That's the goal. Height is just the shortcut our brains reach for. All traits work this way. They're not wrong to have — just one layer too shallow.</p>

--- a/pages/writing.html
+++ b/pages/writing.html
@@ -25,6 +25,22 @@
     <div class="page-body">
 
       <details>
+        <summary> Non-Negotiables, Standards, Preferences (04/06/2026)</summary>
+        <div class="toggle-content">
+          <p>You probably have some list of what you want in someone. "6ft, makes 200k+, kind, emotionally mature." But I'd like to question that today — what does that actually mean? Because to me, your list of traits, when stripped down, are actually about how you want to feel.</p>
+          <p>Height isn't the goal — feeling protected, or small in a way that feels safe. That's the goal. Height is just the shortcut our brains reach for. All traits work this way. They're not wrong to have — just one layer too shallow.</p>
+          <p>We sort that list into categories and use them like they mean the same thing. They don't. And it matters, because I've seen so many people disqualify someone great over something they hadn't thought deeply enough about.</p>
+          <p>A non-negotiable is exactly what it sounds like — absent once, and it's over. A standard is about pattern — one bad day doesn't break it, but consistent absence after you've named it does. A preference is something that makes everything richer without disqualifying anyone.</p>
+          <p>One thing worth saying before the personal part: most of this only becomes load-bearing later. At first, you just notice without verdict. These categories matter when there's real investment, real patterns, and real conversations to be had. Keep that in mind.</p>
+          <p>Personally:</p>
+          <p>I thought I wanted emotional maturity. What I actually wanted was to be fully honest without carefully editing my words first. I thought my standard was calling daily. What I actually wanted was to exist somewhere in their day — just a glimpse, proof that our lives were still woven together even when apart. And a preference of mine is someone who appreciates the little things. A red, majestic tree. The bluejay perched beside it. Someone who gets that every permutation of atoms in every moment is unrepeatable, and finds that worth paying attention to. I can't require this. But it'd be everything.</p>
+          <p>Ultimately, I'm just some SWE with opinions. But I think we owe it to ourselves — and to the people we date, these amazingly, beautifully imperfect people — to know what we're actually looking for. Not just so we stop disqualifying the right people for the wrong reasons, but so we stop staying with the wrong people for the wrong ones too.</p>
+          <p>Asking "how do I want to feel?" is a better start than "what do I want them to have?"</p>
+          <p class="muted">~ Long</p>
+        </div>
+      </details>
+
+      <details>
         <summary> Things I Kept Throwing Away (03/23/2026)</summary>
         <div class="toggle-content">
           <div class="poem">


### PR DESCRIPTION
## Summary
- Adds a new prose essay to the writing section about examining what we actually want in relationships vs. the surface-level traits we list
- Uses the existing `<details>` toggle pattern with `<p>` tags for prose (not the `.poem` structure since this is an essay, not poetry)
- Placed as the first/newest entry above "Things I Kept Throwing Away"

## Test plan
- [ ] Verify the essay renders correctly on the writing page
- [ ] Confirm the collapsible toggle opens/closes properly
- [ ] Check spacing and typography look right on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)