### PR TITLE
feat: rename Love Poetry to Thoughts on Love

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
       <ul class="links">
         <li><a href="pages/engineering.html"><span>✍️</span>Eng Blog</a></li>
         <li><a href="pages/writing.html"><span>📝</span>Writing</a></li>
-        <li><a href="pages/love-poetry.html"><span>💜</span>Love Poetry</a></li>
+        <li><a href="pages/love-poetry.html"><span>💜</span>Thoughts on Love</a></li>
         <li class="row-break" aria-hidden="true" style="flex-basis:100%;height:0;margin:0;padding:0"></li>
         <li class="social-github"><a href="https://github.com/nguyenv119" target="_blank" rel="noopener noreferrer">
           <svg viewBox="0 0 24 24" aria-hidden="true">

--- a/pages/love-poetry.html
+++ b/pages/love-poetry.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Love Poetry — Long Nguyen</title>
+  <title>Thoughts on Love — Long Nguyen</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💜</text></svg>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -17,22 +17,28 @@
 
   <main class="page">
     <div class="page-icon">💜</div>
-    <h1 class="page-title">Love Poetry</h1>
+    <h1 class="page-title">Thoughts on Love</h1>
     <p class="page-subtitle">~ Long</p>
 
     <div class="divider"></div>
 
     <div class="page-body">
-      <p>In an effort to explore how people have expressed love across time – and to finish off my graduation credits – I took a <em>Love Poetry</em> (ENG 50A) class in the Fall of 2025. Admittedly, I also ventured here hoping to illuminate my own clouded feelings from the voices of past poets.</p>
 
-      <p>Having not written/(seriously read) in 4 years, I took it pass/fail — and it was initially <em>tough</em>. Coming from a systems-minded CS & Math background, I was stunned by how vividly my classmates' thoughts bloomed in discussions.</p>
-
-      <p>But, that astonishment turned into inspiration — and, little by little, I let myself speak.</p>
-
-      <p style="color: rgba(201, 169, 110, 0.55);">This space is my offering: a small archive of my appreciation for my classmates, TA, and professor.
-        And for my love for love itself
-        – for people and their beautiful imperfections; for the ordinary days that somehow, quietly, feel like a gift.
-      </p>
+      <details>
+        <summary> What we should actually look for in someone (04/06/2026)</summary>
+        <div class="toggle-content">
+          <p>You probably have some list of what you want in someone. "6ft, makes 200k+, kind, emotionally mature." But I'd like to question that today — what does that actually mean? Because to me, your list of traits, when stripped down, are actually about how you want to feel.</p>
+          <p>Height isn't the goal — feeling protected, or small in a way that feels safe. That's the goal. Height is just the shortcut our brains reach for. All traits work this way. They're not wrong to have — just one layer too shallow.</p>
+          <p>We sort that list into categories and use them like they mean the same thing. They don't. And it matters, because I've seen so many people disqualify someone great over something they hadn't thought deeply enough about.</p>
+          <p>A non-negotiable is exactly what it sounds like — absent once, and it's over. A standard is about pattern — one bad day doesn't break it, but consistent absence after you've named it does. A preference is something that makes everything richer without disqualifying anyone.</p>
+          <p>One thing worth saying before the personal part: most of this only becomes load-bearing later. At first, you just notice without verdict. These categories matter when there's real investment, real patterns, and real conversations to be had. Keep that in mind.</p>
+          <p>Personally:</p>
+          <p>I thought I wanted emotional maturity. What I actually wanted was to be fully honest without carefully editing my words first. I thought my standard was calling daily. What I actually wanted was to exist somewhere in their day — just a glimpse, proof that our lives were still woven together even when apart. And a preference of mine is someone who appreciates the little things. A red, majestic tree. The bluejay perched beside it. Someone who gets that every permutation of atoms in every moment is unrepeatable, and finds that worth paying attention to. I can't require this. But it'd be everything.</p>
+          <p>Ultimately, I'm just some SWE with opinions. But I think we owe it to ourselves — and to the people we date, these amazingly, beautifully imperfect people — to know what we're actually looking for. Not just so we stop disqualifying the right people for the wrong reasons, but so we stop staying with the wrong people for the wrong ones too.</p>
+          <p>Asking "how do I want to feel?" is a better start than "what do I want them to have?"</p>
+          <p class="muted">~ Long</p>
+        </div>
+      </details>
 
       <details open>
         <summary> 🎆 A Beautiful Disorder (12/31/2025)</summary>

--- a/pages/love-poetry.html
+++ b/pages/love-poetry.html
@@ -41,7 +41,7 @@
       </details>
 
       <details open>
-        <summary> 🎆 A Beautiful Disorder (12/31/2025)</summary>
+        <summary> A Beautiful Disorder (12/31/2025)</summary>
         <div class="toggle-content">
           <iv class="poem">
             <div class="stanza">

--- a/pages/writing.html
+++ b/pages/writing.html
@@ -25,22 +25,6 @@
     <div class="page-body">
 
       <details>
-        <summary> What we should actually look for in someone (04/06/2026)</summary>
-        <div class="toggle-content">
-          <p>You probably have some list of what you want in someone. "6ft, makes 200k+, kind, emotionally mature." But I'd like to question that today — what does that actually mean? Because to me, your list of traits, when stripped down, are actually about how you want to feel.</p>
-          <p>Height isn't the goal — feeling protected, or small in a way that feels safe. That's the goal. Height is just the shortcut our brains reach for. All traits work this way. They're not wrong to have — just one layer too shallow.</p>
-          <p>We sort that list into categories and use them like they mean the same thing. They don't. And it matters, because I've seen so many people disqualify someone great over something they hadn't thought deeply enough about.</p>
-          <p>A non-negotiable is exactly what it sounds like — absent once, and it's over. A standard is about pattern — one bad day doesn't break it, but consistent absence after you've named it does. A preference is something that makes everything richer without disqualifying anyone.</p>
-          <p>One thing worth saying before the personal part: most of this only becomes load-bearing later. At first, you just notice without verdict. These categories matter when there's real investment, real patterns, and real conversations to be had. Keep that in mind.</p>
-          <p>Personally:</p>
-          <p>I thought I wanted emotional maturity. What I actually wanted was to be fully honest without carefully editing my words first. I thought my standard was calling daily. What I actually wanted was to exist somewhere in their day — just a glimpse, proof that our lives were still woven together even when apart. And a preference of mine is someone who appreciates the little things. A red, majestic tree. The bluejay perched beside it. Someone who gets that every permutation of atoms in every moment is unrepeatable, and finds that worth paying attention to. I can't require this. But it'd be everything.</p>
-          <p>Ultimately, I'm just some SWE with opinions. But I think we owe it to ourselves — and to the people we date, these amazingly, beautifully imperfect people — to know what we're actually looking for. Not just so we stop disqualifying the right people for the wrong reasons, but so we stop staying with the wrong people for the wrong ones too.</p>
-          <p>Asking "how do I want to feel?" is a better start than "what do I want them to have?"</p>
-          <p class="muted">~ Long</p>
-        </div>
-      </details>
-
-      <details>
         <summary> Things I Kept Throwing Away (03/23/2026)</summary>
         <div class="toggle-content">
           <div class="poem">


### PR DESCRIPTION
## Summary
- Rename "Love Poetry" section to "Thoughts on Love" across the site (page title, nav link, HTML title)
- Remove the poetry course intro/description paragraphs
- Move the "What we should actually look for in someone" essay from Writing to Thoughts on Love

## Changes
- `pages/love-poetry.html` — renamed title, removed intro paragraphs, added the essay
- `pages/writing.html` — removed the essay (only "Things I Kept Throwing Away" remains)
- `index.html` — updated nav link text from "Love Poetry" to "Thoughts on Love"

Generated with Claude Code