### PR TITLE
Add 'Mismatched Routes' essay and refine essay titles

### DIFF
--- a/pages/love-poetry.html
+++ b/pages/love-poetry.html
@@ -25,7 +25,22 @@
     <div class="page-body">
 
       <details>
-        <summary> What we should actually look for in someone (04/06/2026)</summary>
+        <summary> Mismatched Routes (04/12/2026)</summary>
+        <div class="toggle-content">
+          <p>Software is compatible when it can communicate without error. Blood types are compatible when one body can accept another's donation.</p>
+          <p>Compatibility is also the word we use to decide whether to build a life with someone. It sounds clean. Definitive. You either fit or you don't.</p>
+          <p>But these labels of compatibility — attachment style, sex drive, religion, how often you need to talk — are proxies for how we want to feel. Sex is about feeling desired. Attachment is about feeling safe. Everyone wants the same things: to be chosen, to feel free, to be seen. If everyone wants the same destination underneath, then what we're really measuring is how mismatched the routes are. Two people who process conflict the same way, who want the same amount of closeness, who go to bed at the same time — the terrain is smooth, less activation energy required. But two people whose routes look nothing alike? The terrain is rockier. But the destination is the same.</p>
+          <p>Compatibility is the ability to resolve those differences and triggers — a skill hardened through time and willingness.</p>
+          <p>"Compatibility isn't a precondition. It's an accomplishment" ~ Alain de Botton.</p>
+          <p>In a romantic society driven by the idealization of the soulmate — the right relationship flows, love is instinctual — we don't screen for willingness. We screen for route-matching. Same attachment style, same conflict resolution, same sleep schedule. We treat mismatched routes as proof of mismatched destinations. If both people want the same things underneath and are willing to bend their paths to meet in the middle, compatibility is what gets built along the way.</p>
+          <p>But sometimes the cost of bridging that gap causes more suffering than growth. Sometimes one person genuinely lacks the capacity to love — not because of the other person, but because life has made them incapable for now. They're not on a route at all. They're stuck. Other times, the structure is binary: one person needs children, the other needs to remain child-free. Two routes going opposite directions. No middle exists.</p>
+          <p>Walking away from those situations isn't giving up. It is recognizing that love and being together are not the same thing — because often, the most intimate love is to leave them well alone.</p>
+          <p class="muted">~ Long</p>
+        </div>
+      </details>
+
+      <details>
+        <summary> One Layer Too Shallow (04/06/2026)</summary>
         <div class="toggle-content">
           <p>You probably have some list of what you want in someone. "6ft, makes 200k+, kind, emotionally mature." But I'd like to question that today — what does that actually mean? Because to me, your list of traits, when stripped down, are actually about how you want to feel.</p>
           <p>Height isn't the goal — feeling protected, or small in a way that feels safe. That's the goal. Height is just the shortcut our brains reach for. All traits work this way. They're not wrong to have — just one layer too shallow.</p>


### PR DESCRIPTION
## Summary
- Added new essay "Mismatched Routes" (04/12/2026) — explores compatibility as a skill built through willingness, not a precondition to find
- Renamed "What we should actually look for in someone" → "One Layer Too Shallow" to better reflect the essay's core insight

## Key themes in "Mismatched Routes"
- Reframes compatibility from trait-matching to route-matching toward the same destination
- Introduces "activation energy" as the cost of bridging different routes
- Acknowledges genuine structural incompatibilities (kids, incapacity) while arguing most "incompatibility" is convenience mislabeled
- Explores when walking away is the greater love

🤖 Generated with [Claude Code](https://claude.com/claude-code)